### PR TITLE
removed code duplication with the tradoff of non ISO C preprocessor magic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PREFIX    ?= /usr
 MANPREFIX ?= ${PREFIX}/share/man
 
 CPPFLAGS  := -DVERSION=\"${VERSION}\" ${CPPFLAGS}
-CFLAGS    := --std=c99 -g -pedantic -Wall -Wextra ${CFLAGS}
+CFLAGS    := --std=c99 -g -pedantic -Wall -Wextra -Wno-variadic-macros ${CFLAGS}
 LDFLAGS   := -lX11 ${LDFLAGS}
 
 all: ${OUT}

--- a/xrectsel.c
+++ b/xrectsel.c
@@ -7,6 +7,8 @@
 #include <X11/Xlib.h>
 #include <X11/cursorfont.h>
 
+#define die(args...) do {error(args); exit(EXIT_FAILURE); } while(0)
+
 typedef struct Region Region;
 struct Region {
   Window root;
@@ -20,7 +22,6 @@ struct Region {
   unsigned int d; /* depth */
 };
 
-static void die(const char *errstr, ...);
 static void error(const char *errstr, ...);
 static int print_region_attr(const char *fmt, Region region);
 static int select_region(Display *dpy, Window root, Region *region);
@@ -51,17 +52,6 @@ int main(int argc, const char *argv[])
 
   XCloseDisplay(dpy);
   return EXIT_SUCCESS;
-}
-
-static void die(const char *errstr, ...)
-{
-  va_list ap;
-
-  fprintf(stderr, "xrectsel: ");
-  va_start(ap, errstr);
-  vfprintf(stderr, errstr, ap);
-  va_end(ap);
-  exit(EXIT_FAILURE);
 }
 
 static void error(const char *errstr, ...)


### PR DESCRIPTION
Hi lolilolicon,

I recently stumbled over your project and saw that there is a lot of code duplication between error() and die(). I removed that with the tradeoff of using a varargs-macro. I definitely see the point that this breaks ISO-C compliance and macros as functions is always tricky. So of course it is up to you what you prefer. 

Regards, rck
